### PR TITLE
fix(rdma): update SelectRawVerbsDeviceIndex test for 3-arg signature

### DIFF
--- a/src/test/test_raw_verbs_allocator.cpp
+++ b/src/test/test_raw_verbs_allocator.cpp
@@ -32,12 +32,15 @@ TEST(RawVerbsRegionAllocatorTest, RejectsReservedRegionOutsideLocalMemory) {
   EXPECT_THROW(allocator.SetReservedRegion({448, 128}), std::runtime_error);
 }
 
-TEST(RawVerbsDeviceSelectionTest, ClampsNumaIdToAvailableDeviceRange) {
-  EXPECT_EQ(petps::SelectRawVerbsDeviceIndex(0, 4), 0);
-  EXPECT_EQ(petps::SelectRawVerbsDeviceIndex(2, 4), 2);
-  EXPECT_EQ(petps::SelectRawVerbsDeviceIndex(8, 4), 3);
-  EXPECT_EQ(petps::SelectRawVerbsDeviceIndex(-1, 4), 0);
-  EXPECT_EQ(petps::SelectRawVerbsDeviceIndex(3, 0), 0);
+TEST(RawVerbsDeviceSelectionTest, PrefersMatchingNumaThenFallsBack) {
+  const std::vector<int> numa_nodes{0, 1, 2, 3};
+  const std::vector<bool> usable{false, true, true, false};
+
+  EXPECT_EQ(petps::SelectRawVerbsDeviceIndex(2, numa_nodes, usable), 2);
+  EXPECT_EQ(petps::SelectRawVerbsDeviceIndex(8, numa_nodes, usable), 1);
+  EXPECT_EQ(petps::SelectRawVerbsDeviceIndex(-1, numa_nodes, usable), 1);
+  EXPECT_EQ(petps::SelectRawVerbsDeviceIndex(0, numa_nodes, usable), 1);
+  EXPECT_EQ(petps::SelectRawVerbsDeviceIndex(0, {0}, {}), -1);
 }
 
 TEST(RawVerbsEndpointTest, MetaKeyIncludesLocalAndRemoteLanes) {


### PR DESCRIPTION
Commit 4dca44eb changed SelectRawVerbsDeviceIndex from (int numa_id, int num_devices) to
(int numa_id, const std::vector<int>& device_numa_nodes,
     const std::vector<bool>& usable_devices)
but omitted the test update, leaving test_raw_verbs_allocator.cpp calling the old 2-arg form and breaking CI ("invalid initialization of reference of type 'const std::vector<int>&' from expression of type 'int'"). Rewrite the test to exercise the new signature: NUMA-match preference, fallback to first usable device, and -1 on size mismatch.